### PR TITLE
Fix nbdkit bracket notation parsing

### DIFF
--- a/src/parser/__tests__/v2vHelpers.test.ts
+++ b/src/parser/__tests__/v2vHelpers.test.ts
@@ -203,15 +203,21 @@ describe('isErrorFalsePositive', () => {
     expect(isErrorFalsePositive('error: No error')).toBe(true);
   });
 
-  it('returns true for nbdkit debug lines', () => {
-    expect(isErrorFalsePositive('nbdkit: vddk: debug: error in timestamp')).toBe(
+  it('returns true for nbdkit debug lines with &error_fn function pointers', () => {
+    expect(isErrorFalsePositive('nbdkit: debug: VixDiskLib_InitEx (6, 5, &debug_fn, &error_fn, &error_fn, /home/vddk9.0.0, NULL)')).toBe(
       true,
     );
-    expect(isErrorFalsePositive('nbdkit[in]: debug: error in timestamp')).toBe(
+    expect(isErrorFalsePositive('nbdkit[in]: debug: VDDK call: VixDiskLib_InitEx (6, 5, &debug_fn, &error_fn, &error_fn, NULL)')).toBe(
       true,
     );
-    expect(isErrorFalsePositive('nbdkit[out0]: debug: error in timestamp')).toBe(
-      true,
+  });
+
+  it('returns false for nbdkit debug lines with real VDDK errors', () => {
+    expect(isErrorFalsePositive('nbdkit[in]: vddk[4]: debug: 2026-03-19T14:21:44.688-04:00 error -[122802] Cannot use advanced transport modes')).toBe(
+      false,
+    );
+    expect(isErrorFalsePositive('nbdkit[in]: debug: 2026-03-19T14:22:55.343-04:00 error -[122716] User agent failed to send request')).toBe(
+      false,
     );
   });
 

--- a/src/parser/__tests__/v2vHelpers.test.ts
+++ b/src/parser/__tests__/v2vHelpers.test.ts
@@ -31,6 +31,10 @@ describe('categorizeLine', () => {
   it('categorizes nbdkit lines', () => {
     expect(categorizeLine('nbdkit: vddk: debug: connecting')).toBe('nbdkit');
     expect(categorizeLine('running nbdkit --unix /tmp/sock vddk')).toBe('nbdkit');
+    expect(categorizeLine('nbdkit[in]: debug: nbdkit 1.46.2')).toBe('nbdkit');
+    expect(categorizeLine('nbdkit[out]: debug: registered plugin')).toBe('nbdkit');
+    expect(categorizeLine('nbdkit[in0]: debug: TLS disabled')).toBe('nbdkit');
+    expect(categorizeLine('nbdkit[in1]: debug: service mode')).toBe('nbdkit');
   });
 
   it('categorizes libguestfs lines', () => {
@@ -203,6 +207,12 @@ describe('isErrorFalsePositive', () => {
     expect(isErrorFalsePositive('nbdkit: vddk: debug: error in timestamp')).toBe(
       true,
     );
+    expect(isErrorFalsePositive('nbdkit[in]: debug: error in timestamp')).toBe(
+      true,
+    );
+    expect(isErrorFalsePositive('nbdkit[out0]: debug: error in timestamp')).toBe(
+      true,
+    );
   });
 
   it('returns false for real errors', () => {
@@ -217,6 +227,9 @@ describe('isErrorFalsePositive', () => {
 describe('extractSource', () => {
   it('extracts nbdkit', () => {
     expect(extractSource('nbdkit: debug: msg')).toBe('nbdkit');
+    expect(extractSource('nbdkit[in]: debug: msg')).toBe('nbdkit');
+    expect(extractSource('nbdkit[out]: debug: msg')).toBe('nbdkit');
+    expect(extractSource('nbdkit[in0]: debug: msg')).toBe('nbdkit');
   });
 
   it('extracts libguestfs', () => {

--- a/src/parser/v2v/parseHandlers.ts
+++ b/src/parser/v2v/parseHandlers.ts
@@ -378,11 +378,12 @@ export function handleLibvirtXML(ctx: ParseContext, line: string): void {
 export function handleNbdkit(ctx: ParseContext, line: string, globalLine: number): void {
   const isNbdkitStart =
     line.startsWith('running nbdkit:') || line.startsWith('running nbdkit ');
+  const isNbdkitLine = /^nbdkit(\[[^\]]+\])?:/.test(line);
   if (isNbdkitStart) {
     ctx.currentNbdkit = { startLine: globalLine, logLines: [], filters: [] };
   }
 
-  if (isNbdkitStart || line.startsWith('nbdkit:') || (ctx.currentNbdkit && line.startsWith(' '))) {
+  if (isNbdkitStart || isNbdkitLine || (ctx.currentNbdkit && line.startsWith(' '))) {
     if (ctx.currentNbdkit) {
       ctx.currentNbdkit.logLines = ctx.currentNbdkit.logLines || [];
       ctx.currentNbdkit.logLines.push(line);
@@ -440,13 +441,13 @@ export function handleNbdkit(ctx: ParseContext, line: string, globalLine: number
 
     const cowMatch = line.match(COW_FILE_SIZE_RE);
     if (cowMatch && ctx.currentNbdkit) ctx.currentNbdkit.backingSize = parseInt(cowMatch[1], 10);
-  } else if (ctx.currentNbdkit && !line.startsWith('nbdkit:')) {
+  } else if (ctx.currentNbdkit && !isNbdkitLine) {
     finalizeNbdkit(ctx.currentNbdkit, ctx.nbdkitMap, globalLine);
     ctx.currentNbdkit = null;
   }
 
   // Standalone nbdkit log lines
-  if (line.startsWith('nbdkit:') && !ctx.currentNbdkit) {
+  if (isNbdkitLine && !ctx.currentNbdkit) {
     const lastConn = [...ctx.nbdkitMap.values()].pop();
     if (lastConn) {
       lastConn.logLines.push(line);

--- a/src/parser/v2v/v2vHelpers.ts
+++ b/src/parser/v2v/v2vHelpers.ts
@@ -226,8 +226,8 @@ export function isErrorFalsePositive(line: string): boolean {
   for (const fp of ERROR_FALSE_POSITIVES) {
     if (fp.test(line)) return true;
   }
-  // nbdkit debug lines that mention "error" in VDDK timestamps
-  if (NBDKIT_PREFIX_RE.test(line) && line.includes('debug:')) return true;
+  // nbdkit debug lines with &error_fn (VDDK function pointers, not actual errors)
+  if (NBDKIT_PREFIX_RE.test(line) && line.includes('debug:') && /&\w*error\w*_fn/.test(line)) return true;
   return false;
 }
 

--- a/src/parser/v2v/v2vHelpers.ts
+++ b/src/parser/v2v/v2vHelpers.ts
@@ -89,6 +89,9 @@ export const VERSION_VIRTV2V_RE = /^info:\s*(?:virt-v2v[\w-]*):\s*virt-v2v\s+([\
 export const VERSION_LIBVIRT_RE = /^info:\s*libvirt version:\s*([\d.]+)/;
 /** nbdkit 1.38.5 (nbdkit-...) */
 export const VERSION_NBDKIT_RE = /\bnbdkit\s+([\d]+\.[\d]+\.[\d]+)/;
+
+/** nbdkit line prefix: matches nbdkit:, nbdkit[in]:, nbdkit[out]:, nbdkit[in0]:, etc. */
+export const NBDKIT_PREFIX_RE = /^nbdkit(\[[^\]]+\])?:/;
 /** VMware VixDiskLib (7.0.3) Release ... */
 export const VERSION_VDDK_RE = /VMware VixDiskLib \(([\d.]+)\)/;
 /** libguestfs: qemu version: 9.1  or  qemu version (reported by libvirt) = 10000000 */
@@ -159,7 +162,7 @@ export const VERSION_MATCHERS: { key: keyof V2VComponentVersions; re: RegExp; fm
 export function categorizeLine(line: string): V2VLineCategory {
   if (KERNEL_BOOT_RE.test(line)) return 'kernel';
   if (STAGE_RE.test(line)) return 'stage';
-  if (line.startsWith('nbdkit:') || line.startsWith('running nbdkit')) return 'nbdkit';
+  if (NBDKIT_PREFIX_RE.test(line) || line.startsWith('running nbdkit')) return 'nbdkit';
   if (line.startsWith('libguestfs:')) return 'libguestfs';
   if (line.startsWith('guestfsd:')) return 'guestfsd';
   if (line.startsWith('command:') || line.startsWith('commandrvf:') || line.startsWith('chroot:'))
@@ -174,6 +177,8 @@ export function categorizeLine(line: string): V2VLineCategory {
 }
 
 export function isKnownPrefix(line: string): boolean {
+  // nbdkit lines with bracket notation
+  if (NBDKIT_PREFIX_RE.test(line)) return true;
   for (const prefix of KNOWN_PREFIXES) {
     if (line.startsWith(prefix)) return true;
   }
@@ -222,12 +227,12 @@ export function isErrorFalsePositive(line: string): boolean {
     if (fp.test(line)) return true;
   }
   // nbdkit debug lines that mention "error" in VDDK timestamps
-  if (line.startsWith('nbdkit:') && line.includes('debug:')) return true;
+  if (NBDKIT_PREFIX_RE.test(line) && line.includes('debug:')) return true;
   return false;
 }
 
 export function extractSource(line: string): string {
-  if (line.startsWith('nbdkit:')) return 'nbdkit';
+  if (NBDKIT_PREFIX_RE.test(line)) return 'nbdkit';
   if (line.startsWith('libguestfs:')) return 'libguestfs';
   if (line.startsWith('guestfsd:')) return 'guestfsd';
   if (line.startsWith('supermin:')) return 'supermin';


### PR DESCRIPTION
This PR extends nbdkit line detection to handle bracket notation (nbdkit[in]:, nbdkit[out]:, nbdkit[in0]:, etc.) in addition to the standard nbdkit: prefix.


```
$ npm test

> forklift-log-inspector@1.0.0 test
> vitest run


 RUN  v4.0.18 /home/surygupt/src/forklift-log-inspector

 ✓ src/parser/__tests__/planProcessor.test.ts (6 tests) 11ms
 ✓ src/store/__tests__/useV2VStore.test.ts (22 tests) 10ms
 ✓ src/parser/__tests__/fileCopyParser.test.ts (33 tests) 7ms
 ✓ src/utils/__tests__/dateUtils.test.ts (14 tests) 30ms
 ✓ src/parser/__tests__/mergeResults.test.ts (6 tests) 14ms
 ✓ src/parser/__tests__/guestInfoParser.test.ts (38 tests) 51ms
 ✓ src/parser/__tests__/planYamlParser.test.ts (10 tests) 18ms
 ✓ src/parser/__tests__/v2vPathClassifier.test.ts (24 tests) 36ms
 ✓ src/parser/__tests__/v2vLogParser.test.ts (68 tests) 93ms
 ✓ src/parser/__tests__/v2vHelpers.test.ts (57 tests) 11ms
 ✓ src/components/__tests__/UploadZone.test.tsx (1 test) 34ms
 ✓ src/parser/__tests__/utils.test.ts (22 tests) 14ms
 ✓ src/utils/__tests__/badgeUtils.test.ts (11 tests) 9ms
 ✓ src/utils/__tests__/format.test.ts (9 tests) 8ms
 ✓ src/parser/__tests__/logParser.test.ts (6 tests) 5ms
 ✓ src/parser/__tests__/nbdkitParser.test.ts (21 tests) 9ms
 ✓ src/components/__tests__/V2VDashboard.test.tsx (2 tests) 40ms

 Test Files  17 passed (17)
      Tests  350 passed (350)
   Start at  14:29:31
   Duration  2.57s (transform 1.97s, setup 0ms, import 3.27s, tests 400ms, environment 15.49s)

```